### PR TITLE
feat: adds an option to set the walk max depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ Denosass takes both arrays of string, strings and buffers, as shown here :
 const compile = sass(["path/to/some/folder", "path/to/file.scss"]);
 ```
 
+By default it will look for every .scss and .sass file in the subfolders, too. You can limit the depth of the search by setting the walkMaxDepth option.
+
+```ts
+// Here we are limiting the depth to 2, so it will only look for files in the folder and its direct subfolders
+const compile = sass(["path/to/some/folder"], {
+  walkMaxDepth: 2,
+});
+```
+
+```ts
+
 > ### ⚠️ PSA, Denosass perform no Content type check for the file / folder you use, it's entirely up to you. it will look for .scss and .sass file only, ⚠️
 
 Here is an example on how you can use a buffer

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -83,6 +83,7 @@ class Sass implements SassObject {
       load_paths: [Deno.cwd()],
       style: 'compressed',
       quiet: true,
+      walkMaxDepth: Infinity,
     },
   ) {
     this.#input = input;
@@ -335,7 +336,7 @@ class Sass implements SassObject {
     }
     for (
       const entry of walkSync(this.#input as string, {
-        maxDepth: 1,
+        maxDepth: this.options.walkMaxDepth,
         includeDirs: false,
         exts: ['.scss', '.sass'],
       })
@@ -356,7 +357,7 @@ class Sass implements SassObject {
         this.#current.delete(filePath);
         for (
           const entry of walkSync(filePath, {
-            maxDepth: 1,
+            maxDepth: this.options.walkMaxDepth,
             exts: ['.scss', '.sass'],
           })
         ) {

--- a/src/types/module.types.ts
+++ b/src/types/module.types.ts
@@ -8,6 +8,7 @@ export type SassOptions = {
   load_paths?: string[];
   style?: SassFormats;
   quiet?: boolean;
+  walkMaxDepth?: number;
 };
 export type SassFormats = 'expanded' | 'compressed';
 

--- a/tests/folder/global.scss
+++ b/tests/folder/global.scss
@@ -1,0 +1,3 @@
+body {
+    color: green;
+}

--- a/tests/folder/other.scss
+++ b/tests/folder/other.scss
@@ -1,0 +1,3 @@
+body {
+    background-color: black;
+}

--- a/tests/folders_test.ts
+++ b/tests/folders_test.ts
@@ -1,0 +1,24 @@
+import { assertEquals } from "https://deno.land/std@0.125.0/testing/asserts.ts";
+import sass from "../mod.ts";
+
+Deno.test("main_test", async () => {
+  const compiler = sass(["./tests/folder"], {
+    style: "compressed"
+  });
+
+  compiler.to_file({
+    destDir: "./dist",
+    format: "compressed"
+  })
+
+  const globalmintext = await Deno.readTextFile("./dist/global.min.css")
+
+  assertEquals(
+    globalmintext, "body{color:green}"
+  );
+
+  const otehrmintext = await Deno.readTextFile("./dist/other.min.css")
+  assertEquals(
+    otehrmintext, "body{background-color:black}"
+  )
+});


### PR DESCRIPTION
Let's start just with the `walkMaxDepth` option, to keep PRs short and simple.

I am not good at naming things in English, so feel free to change it from walkMaxDepth to maxDepthWalk, or whatever fits better the naming conventions you use.