### PR TITLE
fix: append to the same file

### DIFF
--- a/src/FileWritter.ts
+++ b/src/FileWritter.ts
@@ -10,9 +10,7 @@ export class FileWritter {
     }
     this.files.set(
       filePath,
-      this.files.has(filePath)
-        ? this.files.get(filePath) + data
-        : data
+      this.files.has(filePath) ? this.files.get(filePath) + data : data,
     );
   }
 
@@ -20,7 +18,7 @@ export class FileWritter {
     return Promise.all(
       Array.from(this.files).map(([filePath, data]) =>
         Deno.writeTextFile(filePath, data)
-      )
+      ),
     );
   }
 }

--- a/src/FileWritter.ts
+++ b/src/FileWritter.ts
@@ -1,0 +1,26 @@
+export class FileWritter {
+  private files: Map<string, string>;
+
+  constructor() {
+    this.files = new Map();
+  }
+  append(filePath: string, data: string | Uint8Array) {
+    if (typeof data !== 'string') {
+      data = new TextDecoder().decode(data);
+    }
+    this.files.set(
+      filePath,
+      this.files.has(filePath)
+        ? this.files.get(filePath) + data
+        : data
+    );
+  }
+
+  writeAll() {
+    return Promise.all(
+      Array.from(this.files).map(([filePath, data]) =>
+        Deno.writeTextFile(filePath, data)
+      )
+    );
+  }
+}

--- a/src/types/module.types.ts
+++ b/src/types/module.types.ts
@@ -14,7 +14,7 @@ export type SassFormats = 'expanded' | 'compressed';
 
 export type InputType = string | string[] | Uint8Array;
 export declare interface SassObject {
-  to_file(outputOptions: ExportOptions): boolean;
+  to_file(outputOptions: ExportOptions): Promise<boolean>;
   to_buffer(
     format?: SassFormats,
   ): false | Uint8Array | Map<string, string | Uint8Array>;

--- a/tests/folders_test.ts
+++ b/tests/folders_test.ts
@@ -6,7 +6,7 @@ Deno.test("main_test", async () => {
     style: "compressed"
   });
 
-  compiler.to_file({
+  await compiler.to_file({
     destDir: "./dist",
     format: "compressed"
   })
@@ -22,3 +22,22 @@ Deno.test("main_test", async () => {
     otehrmintext, "body{background-color:black}"
   )
 });
+
+Deno.test("main_test_append", async () => {
+  const compiler = sass(["./tests/folder"], {
+    style: "compressed"
+  });
+
+  await compiler.to_file({
+    destDir: "./dist",
+    format: "compressed",
+    destFile: "appended"
+  })
+
+  const globalmintext = await Deno.readTextFile("./dist/appended.min.css")
+
+  assertEquals(
+    globalmintext, "body{background-color:black}body{color:green}"
+  );
+});
+


### PR DESCRIPTION
This fixes the bug when appending to the same `destFile`

The idea is to use a FileWritter class that instead of flushing directly to the file system, it updates a map with the paths and the file contents.

The files are saved asynchronously at the end, therefore skipping the need to append to files.

I'm not pleased because it feels like a workaround because I could not find out why `Deno.writeTextFileSync` was not appending

But on the other hand, it seems good to make it async, and to abstract the file saving to a different file.

